### PR TITLE
Example of file causing redundant URL information

### DIFF
--- a/tests/examples/paper_redundant_urls.bib
+++ b/tests/examples/paper_redundant_urls.bib
@@ -1,0 +1,35 @@
+
+
+
+
+
+
+@article{doi:10.3366/ijhac.2023.0310,
+author = {Chun, Jon and Elkins, Katherine},
+title = {The Crisis of Artificial Intelligence: A New Digital Humanities Curriculum for Human-Centred AI},
+journal = {International Journal of Humanities and Arts Computing},
+volume = {17},
+number = {2},
+pages = {147-167},
+year = {2023},
+doi = {10.3366/ijhac.2023.0310},
+
+URL = { 
+    
+        https://doi.org/10.3366/ijhac.2023.0310
+    
+    
+
+},
+eprint = { 
+    
+        https://doi.org/10.3366/ijhac.2023.0310
+    
+    
+
+}
+,
+    abstract = { This article outlines what a successful artificial intelligence digital humanities (AI DH) curriculum entails and why it is so critical now. Artificial intelligence is rapidly reshaping our world and is poised to exacerbate long-standing crises including (1) the crisis of higher education and the humanities, (2) the lack of diversity, equity and inclusion (DEI) in computer science and technology fields and (3) the wider social and economic crises facilitated by new technologies. We outline a number of ways in which an AI DH curriculum offers concrete and impactful responses to these many crises. AI DH yields meaningful new avenues of research for the humanities and the humanistic social sciences, and offers new ways that higher education can better prepare students for the world into which they graduate. DEI metrics show how an AI DH curriculum can engage students traditionally underserved by conventional STEM courses. Finally, AI DH educates all students for civic engagement in order to address both the social and economic impacts of emerging AI technologies. This article provides an overview of an AI DH curriculum, the motivating theory behind design decisions, and a detailed look into two sample courses. }
+}
+
+


### PR DESCRIPTION
Parsing this file results in redundant URL information:

Formatted citation HTML (APA7):
Chun, J. &amp; Elkins, K.
(2023).
The crisis of artificial intelligence: a new digital humanities curriculum for human-centred ai. <em>International Journal of Humanities and Arts Computing</em>, <em>17</em>(2), 147-167.
URL: <a href="https://doi.org/10.3366/ijhac.2023.0310">https://doi.org/10.3366/ijhac.2023.0310</a>, <a href="https://arxiv.org/abs/https://doi.org/10.3366/ijhac.2023.0310">arXiv:https://doi.org/10.3366/ijhac.2023.0310</a>, <a href="https://doi.org/10.3366/ijhac.2023.0310">doi:10.3366/ijhac.2023.0310</a>

What also consues me is the non-existant URL https://arxiv.org/abs/https://doi.org/10.3366/ijhac.2023.0310, which is nowhere in the original file. The original file give the DOI in several instances, so we should only grab it once, and the faulty link to Arxiv.org should not even be there.